### PR TITLE
Fix: Resolve tabs getting stuck on loading after Bulma theme conversion

### DIFF
--- a/resources/views/components/hrace009/front/big-frame.blade.php
+++ b/resources/views/components/hrace009/front/big-frame.blade.php
@@ -1,4 +1,4 @@
-<div x-data="setup()" x-init="$refs.loading.classList.add('hidden'); setColors(color);" :class="{ 'dark': isDark}">
+<div x-data="setup()" x-init="loadingState = false; setColors(color);" :class="{ 'dark': isDark}">
     <div class="flex h-screen antialiased text-gray-900 bg-gray-100 dark:bg-dark dark:text-light">
         {{ $slot }}
     </div>

--- a/resources/views/components/hrace009/loading.blade.php
+++ b/resources/views/components/hrace009/loading.blade.php
@@ -1,6 +1,8 @@
 <div
     x-ref="loading"
+    x-show="loadingState"
     class="fixed inset-0 z-50 flex items-center justify-center text-2xl font-semibold text-white bg-primary-darker"
+    style="display: none;"
 >
     {{ $slot }}
 </div>

--- a/resources/views/components/hrace009/theme-script.blade.php
+++ b/resources/views/components/hrace009/theme-script.blade.php
@@ -70,7 +70,7 @@
         }
 
         return {
-            loading: true,
+            loadingState: true,
             isDark: getTheme(),
             toggleTheme() {
                 this.isDark = !this.isDark


### PR DESCRIPTION
The main navigation tabs (Dashboard, Profile) were getting stuck on the loading screen. This was due to how the Alpine.js loading state was managed.

Changes made:
- Modified `loading.blade.php` to use `x-show="loadingState"` for visibility, binding it to an Alpine.js state.
- Updated `theme-script.blade.php` to initialize `loadingState: true` in its `setup()` function.
- Updated `big-frame.blade.php` to set `loadingState = false` in its `x-init` directive, ensuring the loader is hidden once Alpine initializes on page load.

These changes ensure that the loading screen's visibility is properly controlled by Alpine.js state and is correctly hidden after page loads, resolving the issue with tabs appearing stuck.